### PR TITLE
Set supported chef client to 12.12.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This cookbook provides resources for the installation of Tripwire Enterprise Axo
 
 ## Requirements
 
-* Chef 12.5 or higher
+* Chef 12.12.15 or higher
 * Tripwire Enterprise installers available through a share or web service
 
 ## Provider Documentation

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+version '0.1.2'
+chef_version '>= 12.12.15' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'
 issues_url 'https://github.com/Tripwire/chef-tripwire_agent/issues'


### PR DESCRIPTION
== STORY / BUGS

Resolves #1

== DETAILS

Ohai capturing package information is supported in a later versions of
the chef client. Use 12.12.15 instead of 12.1 or 12.5.