### PR TITLE
Fixed config_directory property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tripwire_agent Cookbook CHANGELOG
 
+## TBD
+
+Fixed tripwire_agent_axon property config_directory default fixed
+
 ## 0.1.5 (2017-11-10)
 
 Expanding axon's resources to support co-existing agents for TE, TLC, and IP360

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.5'
+version '0.1.6'
 chef_version '>= 12.12.15' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -22,7 +22,7 @@ property :clean,                  [true, false], default: true
 property :tags,                   Hash, default: {}
 if node['platform'] == 'windows'
   property  :install_directory,   String,   default: 'C:\Program Files\Tripwire\Agent'
-  property  :config_directory,    String,   default: 'C:\ProgramData\Tripwire\Agent'
+  property  :config_directory,    String,   default: 'C:\ProgramData\Tripwire\Agent\config'
   property  :service_name,        String,   default: 'TripwireAxonAgent'
 else
   property  :install_directory,   String,   default: '/opt/tripwire/agent'


### PR DESCRIPTION
== STORY / BUGS

Resolves #13

== DETAILS

I made a mistake when I added the config_directory property, leaving
the config directory off the path. This mistake has been resolved.

== TESTING

kitchen test