### PR TITLE
Adding support for oracle in axon custom resource

### DIFF
--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -57,7 +57,7 @@ action :install do
 
   # Set platform specific variables
   case node['platform']
-  when  'centos', 'redhat', 'suse', 'oraclelinux'
+  when  'centos', 'redhat', 'suse', 'oraclelinux', 'oracle'
     ext = '.rpm'
     eg_service_name = 'tw-eg-service'
   when 'debian', 'ubuntu'


### PR DESCRIPTION
The custom resource for Axon will break when the platform is 'oracle'. The platform case statement should include 'oracle' as well as 'oraclelinux'.

Regex may be a better alternative.