### PR TITLE
Fix: Using correct package resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,13 +4,6 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: true
-  chef_omnibus_url: https://www.chef.io/chef/install.sh
-  # You may wish to disable always updating cookbooks in CI or other testing environments.
-  # For example:
-  #   always_update_cookbooks: <%= !ENV['CI'] %>
-  always_update_cookbooks: true
-
 verifier:
   name: inspec
 
@@ -414,7 +407,7 @@ suites:
         - test/smoke/axon-basic
     excludes:
       - a_centos_type
-      - a_windows_type
+      - a_debian_type
     attributes:
       tripwire_agent:
         installer: 'D:\Path\To\Axon_Agent_x64.msi'
@@ -431,7 +424,7 @@ suites:
         - test/smoke/axon-comprehensive
     excludes:
       - a_centos_type
-      - a_windows_type
+      - a_debian_type
     attributes:
       tripwire_agent:
         installer: 'D:\Path\To\Axon_Agent_x64.msi'

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ run_list:
 
 * Axon agents requires some method of knowing about the bridge, either through DNS pointer record or manually configuring the bridge through the attribute or when using the resource in your cookbook.
   * Please see the Installation and Maintenance guide for any additional information
+* Installation of the DKMS driver for the event generator service requires that the DKMS package is already installed on the system.
 * Axon Windows agents will automatically start post installation
   * Linux Axon agents can be prevented from starting post installation
   * Java agents for Windows and Linux can be prevented from starting post installation

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.6'
+version '0.1.7'
 chef_version '>= 12.12.15' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'


### PR DESCRIPTION
The installation and maintenance guide for the Axon Agent specifies
that the RPM package manager should be used in order to install
the Axon Agent and its related drivers and eg service package for
rhel systems and dpkg for debian based systems.

The previous implementation allowed for the use of a generic package
resource and the OS would choose the correct package to use. In this
case, redhat based systems would choose to use yum, although the
supported installation method was actually RPM.

This commit specifies the use of the rpm_package resource for all
redhat platform families, dpkg_package resource for all debian based
platform families, and a generic package resource for all other for
backwards compatibility.

Also, this commit slightly refactors deprecated code which becomes
 hard errors on Chef 14. Cleaned up linter errors as well.

Kitchen tests pass on:
Ubuntu 1404
Ubuntu 1804
Rhel 5.11
Rhel 7.4

Also tested agents connecting to a TE console with the following
configurations:
RHEL 5.11 x64
RHEL 6.0 x86
RHEL 7.5 x64
Oracle 6.7 UEK
Ubuntu 1404
Ubuntu 1604
Windows 2k8 x64
Windows 2016 x64

Fixes #22, Fixes #18