### PR TITLE
Fix Java Remove Cookbook Errors and Deprecation Warnings

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.7'
+version '0.1.8'
 chef_version '>= 12.12.15' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -17,33 +17,8 @@ test_systems.each do |test_platform, test_version|
         runner = ChefSpec::ServerRunner.new(platform: test_platform, version: test_version)
         runner.converge(described_recipe)
       end
-
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
-      end
-
-      it 'copies the agent to the local cache' do
-
-      end
-
-      it 'writes the java ttagging template file' do
-
-      end
-
-      it 'installs the agent to the local system' do
-
-      end
-
-      it 'starts the rtm service' do
-
-      end
-
-      it 'starts the agent service' do
-
-      end
-
-      it 'deletes the agent installer from the local cache' do
-
       end
     end
   end

--- a/spec/unit/recipes/java_agent_spec.rb
+++ b/spec/unit/recipes/java_agent_spec.rb
@@ -17,33 +17,8 @@ test_systems.each do |test_platform, test_version|
         runner = ChefSpec::ServerRunner.new(platform: test_platform, version: test_version)
         runner.converge(described_recipe)
       end
-
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
-      end
-
-      it 'copies the agent to the local cache' do
-
-      end
-
-      it 'writes the java ttagging template file' do
-
-      end
-
-      it 'installs the agent to the local system' do
-
-      end
-
-      it 'starts the rtm service' do
-
-      end
-
-      it 'starts the agent service' do
-
-      end
-
-      it 'deletes the agent installer from the local cache' do
-
       end
     end
   end

--- a/spec/unit/recipes/java_uninstall_spec.rb
+++ b/spec/unit/recipes/java_uninstall_spec.rb
@@ -13,7 +13,6 @@ describe 'tripwire_agent::java_uninstall' do
       runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
       runner.converge(described_recipe)
     end
-
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
     end


### PR DESCRIPTION
These commits fix three errors associated with the Java Remove
cookbook as well as linting warnings in the spec files.

To support Chef 13 features, the properties used in the
cookbook needed to be updated to include new_resource as a part of the
new Chef 13 format. Without this change, newer versions of Chef would
report a hard error of unknown resource.

The second issue resolved includes the attempt of using a log resource
within the execute resource for the uninstallation of the Java Agent.
The logging resource is not recognized within the execute resource
(rightfully so) and foodcritic flags this error with resource
attribute not recognized. This commit resolves #6.

In testing we found an additional bug where the cookbook tries to run
systemctl on pre Debian 8.0 machines. Systemctl became the standard
after Debian 8.0 Jessie. We added a conditional to ensure that we
don't attempt to call systemctl pre Debian 8.0

Ran integration tests on the following platforms:
Windows 2012r2 64 bit
Debian 7.8 64 bit
Debian 6.0.10 64 bit
Centos 7.4 64 bit