### PR TITLE
Support handling compressed files for Axon

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -247,6 +247,7 @@ suites:
       tripwire_agent:
         installer: '/path/to/axon-agent-installer-linux-x64.rpm'
         axon:
+          eg_install: false
           bridge: 'tw-bridge.example.com'
           registration_key: '123PAs5W0rD'
         tags: { 'tagset1': 'tag1a' , 'tagset2': [ 'tag2a', 'tag2b' ],'tagset3': [ 'tag3a', 'tag3b', 'tag3c' ] }
@@ -351,6 +352,7 @@ suites:
         axon:
           bridge: 'tw-bridge.example.com'
           registration_key: '123PAs5W0rD'
+          eg_install: false
         tags: { 'tagset1': 'tag1a' , 'tagset2': [ 'tag2a', 'tag2b' ],'tagset3': [ 'tag3a', 'tag3b', 'tag3c' ] }
 
   - name: axon-deb-comp

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This cookbook provides resources for the installation of Tripwire Enterprise Axo
 | ['tripwire_agent']['java']['fips'] | Boolean | Enables FIPS mode on the java agent | false | No | - |
 | ['tripwire_agent']['java']['integration_port'] | Integer | Configures the integration port used by the Tripwire Enterprise Console, only set if FIPS is enabled | 8080 | No | - |
 | ['tripwire_agent']['java']['install_directory'] | String | Modifies the default installation directory for the agent | Windows: `C:\Program Files\Tripwire\TE\Agent` Linux: `/usr/local/tripwire/te/agent` | No | - |
-| ['tripwire_agent']['axon']['eg_install'] | Boolean | Install the event generator driver and the eveng generator service (linux/debian only) | Yes | - | Yes |
+| ['tripwire_agent']['axon']['eg_install'] | Boolean | Install the event generator driver and the event generator service (linux/debian only) | Yes | - | Yes |
 | ['tripwire_agent']['axon']['use_dkms_driver'] | Boolean | If a tar file was set for the `installer` and `eg_install` is set to `true`, this flag instructs to install the DKMS driver if set to true | false | - | No |
 | ['tripwire_agent']['axon']['eg_driver_installer'] | String | Event Generator installer for linux | nil | - | No |
 | ['tripwire_agent']['axon']['eg_service_installer'] | String | Event Generator service installer for linux | nil | - | No |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['tripwire_agent']['java']['removeall'] = true
 # Axon specific
 default['tripwire_agent']['axon']['eg_driver_installer'] = nil
 default['tripwire_agent']['axon']['eg_service_installer'] = nil
+default['tripwire_agent']['axon']['use_dkms_driver'] = false
 default['tripwire_agent']['axon']['eg_install'] = true
 default['tripwire_agent']['axon']['bridge'] = nil
 default['tripwire_agent']['axon']['bridge_port'] = 5670

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -257,7 +257,7 @@ action :remove do
     config_path = '/etc/tripwire'
   when 'suse'
     agent_package = 'axon-agent'
-    eg_driver_package = node['packages'].include?('tw-eg-driver-dkms') ? 'tw-eg-driver-dkms' : 'tw-eg-driver-suse'
+    eg_driver_package = 'tw-eg-driver-suse'
     eg_service_package = 'tw-eg-service'
     config_path = '/etc/tripwire'
   when 'windows'

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -119,7 +119,7 @@ action :install do
       # Use the license file for idempotency
       creates "#{axon_chef_cache}/license.html"
     end
-  elsif agent_source.end_with?('zip')
+  elsif agent_source_is_zip
     windows_zipfile 'windows_zip' do
       source agent_source
       path ::Chef::Config['file_cache_path']

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -1,33 +1,34 @@
-property :installer,              [String, nil], name_property: true
-property :eg_driver_installer,    [String, nil], default: nil
-property :eg_service_installer,   [String, nil], default: nil
-property :eg_install,             [true, false], default: true
-property :dns_srvc_name,          String, default: '_tw_gw'
-property :dns_srvc_domain,        [String, nil], default: nil
-property :bridge_auth_mode,       [String, nil], default: 'registration'
-property :keystore_password,      [String, nil], default: nil
-property :registration_filename,  String, default: 'registration_pre_shared_key.txt'
-property :registration_key,       [String, nil], default: nil
-property :proxy_hostname,         [String, nil], default: nil
-property :proxy_port,             Integer, default: 1080
-property :proxy_username,         [String, nil], default: nil
-property :proxy_password,         [String, nil], default: nil
-property :tls_version,            [String, nil], default: nil
-property :cipher_suites,          [String, nil], default: nil
-property :spool_size,             String, default: '1g'
-property :bridge,                 [String, nil], default: nil
-property :bridge_port,            Integer, default: 5670
-property :start_service,          [true, false], default: true
-property :clean,                  [true, false], default: true
-property :tags,                   Hash, default: {}
+property :installer, [String, nil], name_property: true
+property :eg_driver_installer, [String, nil], default: nil
+property :eg_service_installer, [String, nil], default: nil
+property :eg_install, [true, false], default: true
+property :dns_srvc_name, String, default: '_tw_gw'
+property :dns_srvc_domain, [String, nil], default: nil
+property :bridge_auth_mode, [String, nil], default: 'registration'
+property :keystore_password, [String, nil], default: nil
+property :registration_filename, String, default: 'registration_pre_shared_key.txt'
+property :registration_key, [String, nil], default: nil
+property :proxy_hostname, [String, nil], default: nil
+property :proxy_port, Integer, default: 1080
+property :proxy_username, [String, nil], default: nil
+property :proxy_password, [String, nil], default: nil
+property :tls_version, [String, nil], default: nil
+property :cipher_suites, [String, nil], default: nil
+property :spool_size, String, default: '1g'
+property :bridge, [String, nil], default: nil
+property :bridge_port, Integer, default: 5670
+property :start_service, [true, false], default: true
+property :clean, [true, false], default: true
+property :tags, Hash, default: {}
+property :use_dkms_driver, [true, false], default: false
 if node['platform'] == 'windows'
-  property  :install_directory,   String,   default: 'C:\Program Files\Tripwire\Agent'
-  property  :config_directory,    String,   default: 'C:\ProgramData\Tripwire\Agent\config'
-  property  :service_name,        String,   default: 'TripwireAxonAgent'
+  property :install_directory, String, default: 'C:\Program Files\Tripwire\Agent'
+  property :config_directory, String, default: 'C:\ProgramData\Tripwire\Agent\config'
+  property :service_name, String, default: 'TripwireAxonAgent'
 else
-  property  :install_directory,   String,   default: '/opt/tripwire/agent'
-  property  :config_directory,    String,   default: '/etc/tripwire'
-  property  :service_name,        String,   default: 'tripwire-axon-agent'
+  property :install_directory, String, default: '/opt/tripwire/agent'
+  property :config_directory, String, default: '/etc/tripwire'
+  property :service_name, String, default: 'tripwire-axon-agent'
 end
 
 default_action :install
@@ -57,7 +58,7 @@ action :install do
 
   # Set platform specific variables
   case node['platform']
-  when  'centos', 'redhat', 'suse', 'oraclelinux', 'oracle'
+  when 'centos', 'redhat', 'suse', 'oraclelinux', 'oracle'
     ext = '.rpm'
     eg_service_name = 'tw-eg-service'
   when 'debian', 'ubuntu'
@@ -98,82 +99,132 @@ action :install do
     not_if { new_resource.tags.empty? }
   end
 
-  # Set local cache target for the installers
-  local_installer = ::Chef::Config['file_cache_path'] + '/te_agent' + ext
+  agent_source_is_url = new_resource.installer.start_with?('http')
+  agent_source_is_tgz = new_resource.installer.end_with?('tgz')
+  agent_source_is_zip = new_resource.installer.end_with?('zip')
 
   # Set the correct header for the agent installer
-  agent_source = if new_resource.installer.start_with?('http')
-                   new_resource.installer
-                 else
-                   'file:///' + new_resource.installer
-                 end
+  agent_source = agent_source_is_url ? new_resource.installer : 'file:///' + new_resource.installer
+  folder = ::File.basename(agent_source, '.*')
+  axon_chef_cache = "#{::Chef::Config['file_cache_path']}/#{folder}"
 
-  # Download installer
-  remote_file local_installer do
-    source agent_source
-    mode '744' unless node['platform'] == 'windows'
+  # Set local cache target for the installers
+  node.run_state['local_installer'] = "#{::Chef::Config['file_cache_path']}/te_axon#{ext}"
+
+  # Download and unzip the installer
+  if agent_source_is_tgz
+    tar_extract agent_source do
+      target_dir ::Chef::Config['file_cache_path']
+      action :extract
+      # Use the license file for idempotency
+      creates "#{axon_chef_cache}/license.html"
+    end
+  elsif agent_source.end_with?('zip')
+    windows_zipfile 'windows_zip' do
+      source agent_source
+      path ::Chef::Config['file_cache_path']
+      action :unzip
+    end
+  else
+    remote_file node.run_state['local_installer'] do
+      source agent_source
+      mode '744' unless node['platform'] == 'windows'
+    end
   end
 
-  if node['platform'] != 'windows' && (new_resource.eg_driver_installer != nil || new_resource.eg_service_installer != nil)
+  # Automatically set the sources from the compressed file
+  if agent_source_is_tgz || agent_source_is_zip
+    ruby_block 'get files' do
+      block do
+        files = ::Dir.entries(axon_chef_cache)
+        file_string = agent_source_is_tgz ? 'agent-installer' : 'Axon_Agent'
+        installer_basename = files.find { |item| item.include?(file_string) }
 
-    # Set local cache target for the driver and service
-    local_eg_driver = ::Chef::Config['file_cache_path'] + '/eg_driver' + ext
-    local_eg_service = ::Chef::Config['file_cache_path'] + '/eg_service' + ext
+        # Set the local installer location
+        node.run_state['local_installer'] = "#{axon_chef_cache}/#{installer_basename}"
+
+        log lazy { node.run_state['local_installer'] }
+
+        # Only necessary to set these if a linux box
+        if new_resource.eg_install && !platform_family?('windows')
+          service_basename = files.find { |item| item.include?('service') }
+          driver_basename = files.find { |item| item.include?(new_resource.use_dkms_driver ? 'driver-dkms' : 'driver') }
+
+          # Determine the local driver and service locations
+          local_eg_service = "#{axon_chef_cache}/#{service_basename}"
+          local_eg_driver = "#{axon_chef_cache}/#{driver_basename}"
+          node.run_state['local_eg_service'] = local_eg_service
+          node.run_state['local_eg_driver'] = local_eg_driver
+        end
+      end
+      action :run
+    end
+  elsif new_resource.eg_install && (!new_resource.eg_service_installer.nil? || !new_resource.eg_driver_installer.nil?)
+    # In case we have not set the driver and service, we can assume they
+    # were manually specified and need to download them to the node.
+    node.run_state['local_eg_driver'] = ::Chef::Config['file_cache_path'] + '/eg_driver' + ext
+    node.run_state['local_eg_service'] = ::Chef::Config['file_cache_path'] + '/eg_service' + ext
 
     # Set the correct header for the eg driver installer
-    eg_driver_source = if new_resource.eg_driver_installer.start_with?('http') && new_resource.eg_install
-                         new_resource.eg_driver_installer
-                       else
-                         'file:///' + new_resource.eg_driver_installer
-                       end
+    eg_driver_source = new_resource.eg_driver_installer.start_with?('http') && new_resource.eg_install ? new_resource.eg_driver_installer : 'file:///' + new_resource.eg_driver_installer
 
     # Set the corret header for the eg service installer
-    eg_service_source = if new_resource.eg_service_installer.start_with?('http') && new_resource.eg_install
-                          new_resource.eg_service_installer
-                        else
-                          'file:///' + new_resource.eg_service_installer
-                        end
+    eg_service_source = new_resource.eg_service_installer.start_with?('http') && new_resource.eg_install ? new_resource.eg_service_installer : 'file:///' + new_resource.eg_service_installer
 
     # Install package eg if enabled & not windows
-    remote_file local_eg_driver do
+    remote_file lazy { node.run_state['local_eg_driver'] } do
       source eg_driver_source
       mode '0744'
     end
-    remote_file local_eg_service do
+    remote_file lazy { node.run_state['local_eg_service'] } do
       source eg_service_source
       mode '0744'
     end
+  end
 
-    # Install EG driver and service
-    [local_eg_driver, local_eg_service].each do |pkg|
+  # If the service installer or the driver installer are not specified, we will not install unless
+  # the agent source is a tgz file. In this case the installers do not need to be set since they were derived
+  # in the tgz.
+  eg_specified = (!new_resource.eg_driver_installer.nil? && !new_resource.eg_service_installer.nil?) || agent_source_is_tgz
+  install_eg_components = !platform?('windows') && eg_specified && new_resource.eg_install
+
+  if install_eg_components
+    # Install EG driver
+    %w(local_eg_driver local_eg_service).each do |name|
       if platform_family?('debian')
-        dpkg_package pkg do
+        dpkg_package 'pkg' do
+          package_name lazy { node.run_state[name] }
           action :install
         end
       elsif platform_family?('rhel')
-        rpm_package pkg do
+        rpm_package 'pkg' do
+          package_name lazy { node.run_state[name] }
           action :install
         end
       else
         # All other platforms we use generic packages
-        package pkg do
+        package 'pkg' do
+          package_name lazy { node.run_state[name] }
           action :install
         end
       end
     end
   end
 
+  log lazy { node.run_state['local_installer'] }
+
   # Install the actual agent
   if platform_family?('debian')
-    dpkg_package local_installer do
+    dpkg_package lazy { node.run_state['local_installer'] } do
       action :install
     end
   elsif platform_family?('rhel')
-    rpm_package local_installer do
+    rpm_package lazy { node.run_state['local_installer'] } do
       action :install
     end
   else
-    package local_installer do
+    package 'axon installer' do
+      source lazy { node.run_state['local_installer'] }
       action :install
     end
   end
@@ -182,7 +233,7 @@ action :install do
   # Windows Axon agents start the service automatically
   service eg_service_name do
     action :start
-    only_if { new_resource.start_service && node['platform'] != 'windows' && (new_resource.eg_driver_installer != nil || new_resource.eg_service_installer != nil) }
+    only_if { new_resource.start_service && node['platform'] != 'windows' && new_resource.eg_install && (!new_resource.eg_driver_installer.nil? && !new_resource.eg_service_installer.nil?) }
   end
   service service_name do
     action :start
@@ -196,29 +247,17 @@ action :remove do
   case node['platform']
   when 'centos', 'redhat', 'oraclelinux'
     agent_package = 'axon-agent'
-    if node['packages'].include?('tw-eg-driver-dkms')
-      eg_driver_package = 'tw-eg-driver-dkms'
-    else
-      eg_driver_package = 'tw-eg-driver-rhel'
-    end
+    eg_driver_package = node['packages'].include?('tw-eg-driver-dkms') ? 'tw-eg-driver-dkms' : 'tw-eg-driver-rhel'
     eg_service_package = 'tw-eg-service'
     config_path = '/etc/tripwire'
   when 'debian', 'ubuntu'
     agent_package = 'axon-agent'
-    if node['packages'].include?('tw-eg-driver-dkms')
-      eg_driver_package = 'tw-eg-driver-dkms'
-    else
-      eg_driver_package = 'tw-eg-driver-debian'
-    end
+    eg_driver_package = node['packages'].include?('tw-eg-driver-dkms') ? 'tw-eg-driver-dkms' : 'tw-eg-driver-debian'
     eg_service_package = 'tw-eg-service'
     config_path = '/etc/tripwire'
   when 'suse'
     agent_package = 'axon-agent'
-    if node['packages'].include?('tw-eg-driver-dkms')
-      eg_driver_package = 'tw-eg-driver-dkms'
-    else
-      eg_driver_package = 'tw-eg-driver-suse'
-    end
+    eg_driver_package = node['packages'].include?('tw-eg-driver-dkms') ? 'tw-eg-driver-dkms' : 'tw-eg-driver-suse'
     eg_service_package = 'tw-eg-service'
     config_path = '/etc/tripwire'
   when 'windows'
@@ -229,7 +268,7 @@ action :remove do
   end
 
   # Remove EG service and Driver on non-Windows platforms
-  if !platform?('windows')
+  unless platform?('windows')
     [eg_service_package, eg_driver_package].each do |pkg|
       if platform_family?('debian')
         dpkg_package pkg do

--- a/test/smoke/axon-basic/axon_agent_test.rb
+++ b/test/smoke/axon-basic/axon_agent_test.rb
@@ -40,7 +40,7 @@ describe file(config_file) do
   # Following should not exist in the file
   its('content') { should_not match /dns\.service\.name=bridge/ }
   its('content') { should_not match /dns\.service\.domain=example\.com/ }
-  its('content') { should_not match /socks5\.*/}
+  its('content') { should_not match /socks5\.*/ }
   its('content') { should_not match /tls\.version*/ }
   its('content') { should_not match /tls\.cipher\.suites*/ }
 end
@@ -51,9 +51,9 @@ describe file(tag_file) do
 end
 
 describe yaml(tag_file) do
-  its(['tagSets', 'tagset1']) { should eq 'tag1a'}
-  its(['tagSets', 'tagset2']) { should eq ['tag2a', 'tag2b']}
-  its(['tagSets', 'tagset3']) { should eq ['tag3a', 'tag3b', 'tag3c']}
+  its(%w(tagSets tagset1)) { should eq 'tag1a' }
+  its(%w(tagSets tagset2)) { should eq %w(tag2a tag2b) }
+  its(%w(tagSets tagset3)) { should eq %w(tag3a tag3b tag3c) }
 end
 
 # Axon agents registration key should exist and contain the test password

--- a/test/smoke/axon-comprehensive/axon_comp_test.rb
+++ b/test/smoke/axon-comprehensive/axon_comp_test.rb
@@ -35,10 +35,10 @@ describe file(config_file) do
   it { should exist }
   its('content') { should match /dns\.service\.name=bridge/ }
   its('content') { should match /dns\.service\.domain=example\.com/ }
-  its('content') { should match /socks5\.host=tw-proxy\.example\.com/}
+  its('content') { should match /socks5\.host=tw-proxy\.example\.com/ }
   its('content') { should match /socks5\.port=1180/ }
   its('content') { should match /socks5\.user\.name=twsocks01/ }
-  its('content') { should match /socks5\.user\.password=T357pAs5W0rD!/}
+  its('content') { should match /socks5\.user\.password=T357pAs5W0rD!/ }
   its('content') { should match /spool\.size\.max=3g/ }
   its('content') { should match /tls\.version=TLSv1\.1/ }
   its('content') { should match /tls\.cipher\.suites=AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384/ }

--- a/test/smoke/axon-ip360/axon_agent_test.rb
+++ b/test/smoke/axon-ip360/axon_agent_test.rb
@@ -34,7 +34,7 @@ describe file(config_file) do
   # Following should not exist in the file
   its('content') { should_not match /dns\.service\.name=bridge/ }
   its('content') { should_not match /dns\.service\.domain=example\.com/ }
-  its('content') { should_not match /socks5\.*/}
+  its('content') { should_not match /socks5\.*/ }
   its('content') { should_not match /tls\.version*/ }
   its('content') { should_not match /tls\.cipher\.suites*/ }
 end

--- a/test/smoke/axon-noeg/axon_agent_test.rb
+++ b/test/smoke/axon-noeg/axon_agent_test.rb
@@ -40,7 +40,7 @@ describe file(config_file) do
   # Following should not exist in the file
   its('content') { should_not match /dns\.service\.name=bridge/ }
   its('content') { should_not match /dns\.service\.domain=example\.com/ }
-  its('content') { should_not match /socks5\.*/}
+  its('content') { should_not match /socks5\.*/ }
   its('content') { should_not match /tls\.version*/ }
   its('content') { should_not match /tls\.cipher\.suites*/ }
 end
@@ -51,9 +51,9 @@ describe file(tag_file) do
 end
 
 describe yaml(tag_file) do
-  its(['tagSets', 'tagset1']) { should eq 'tag1a'}
-  its(['tagSets', 'tagset2']) { should eq ['tag2a', 'tag2b']}
-  its(['tagSets', 'tagset3']) { should eq ['tag3a', 'tag3b', 'tag3c']}
+  its(%w(tagSets tagset1)) { should eq 'tag1a' }
+  its(%w(tagSets tagset2)) { should eq %w(tag2a tag2b) }
+  its(%w(tagSets tagset3)) { should eq %w(tag3a tag3b tag3c) }
 end
 
 # Axon agents registration key should exist and contain the test password


### PR DESCRIPTION
We provide the axon agent bundle in a tar file (tgz) and a zip file
to our customers. For the linux Axon Agent, this feature allows
the customer to install the agent using this cookbook by specifying
a location to either multiple bin files for the eg driver, service
and agent, or the compressed tar file that is shipped. For the
windows Axon Agent, the user can specify either the location of
the Axon Agent MSI or the zip file that is provided.

Tested using the traditional bin file install options as well as
the tar install options on Centos 72 and Debian 8. Tested using
the Windows MSI installers directly as well as the shipped zip
files.

All kitchen tests were ran on the above platforms, updated kitchen
tests where necessary.

Also addressed any foodcritic / cookstyle linter errors and
warnings.