### PR TITLE
Axon recipe is selecting the wrong eg-driver (Issue #37)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.0'
+version '1.1.1'
 chef_version '>= 13' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'

--- a/recipes/axon_agent.rb
+++ b/recipes/axon_agent.rb
@@ -6,6 +6,7 @@
 tripwire_agent_axon 'Install Tripwire Axon agent' do
   installer node['tripwire_agent']['installer']
   eg_install node['tripwire_agent']['axon']['eg_install']
+  use_dkms_driver node['tripwire_agent']['axon']['use_dkms_driver']
   eg_driver_installer node['tripwire_agent']['axon']['eg_driver_installer']
   eg_service_installer node['tripwire_agent']['axon']['eg_service_installer']
   install_directory node['tripwire_agent']['axon']['install_directory']

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -148,7 +148,17 @@ action :install do
         # Only necessary to set these if a linux box
         if new_resource.eg_install && !platform_family?('windows')
           service_basename = files.find { |item| item.include?('service') }
-          driver_basename = files.find { |item| item.include?(new_resource.use_dkms_driver ? 'driver-dkms' : 'driver') }
+          if new_resource.use_dkms_driver
+            driver_basename = files.find { |item| item.include?('driver-dkms')}
+          else
+            # There can be multiple eg-driver files e.g driver-dkms, driver-rhel, driver-suse
+            driver_basename_list = files.select { |item| item.include?('driver') and !item.include?('driver-dkms')}
+            if !platform_family?('suse')
+              driver_basename = driver_basename_list.find {|item| !item.include?('suse') }
+            else
+              driver_basename = driver_basename_list.find {|item| item.include?('suse') }
+            end
+          end
 
           # Determine the local driver and service locations
           local_eg_service = "#{axon_chef_cache}/#{service_basename}"


### PR DESCRIPTION
This change addresses following issues (including #37 ):

1. the recent(so to say) TGZ from Tripwire contains eg-drivers for DKMS, RHEL and SUSE. The code on line 151 of axon.rb appears to always select the first matching entry in the directory, which is often DKMS/SUSE,

2. additionally, 'use_dkms_driver' attribute was not handled in 'axon_agent' recipe. Due to which, it always picked the default value i.e. 'false',

**Testing :** 

sr no | platform | axon version | result without this change | result with this change | comment
-- | -- | -- | -- | -- | --
1 | Rhel 7.x x64 | 8.8.3.1 | fail | pass | ealier it would pick dkms/suse-driver
2 | Rhel 7.x x64 | 8.8.0.2 | pass | pass |  
3 | Rhel 6.9 x86 | 8.8.3.1 | fail | pass | ealier it would pick dkms-driver
4 | Rhel 6.9 x86 | 8.8.0.2 | pass | pass |  
5 | Debian 10.x x64 | 8.8.3.1 | fail | pass | ealier it would pick dkms-driver
6 | Debian 810 x64 | 8.8.0.2 | pass | pass |  
7 | Suse 15.x x64 | 8.8.3.1 | fail | fail | Seems to be issue with existing code, so should be handled as separate issue/PR.
8 | Oracle-linux | 8.8.3.1 | fail | fail | now use_dkms attribute is correctly picked, although when set to ‘true’, installation fails. But, that again seems to be issue with existing code, so should be handled as separate issue/PR.

@pfaffle 


