### PR TITLE
Handled code to install axonagent on suse12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.2'
+version '1.1.3'
 chef_version '>= 13' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -227,7 +227,8 @@ action :install do
           package_name lazy { node.run_state[name] }
           action :install
         end
-      elsif platform_family?('rhel')
+      #Currently support on suse12
+      elsif platform_family?('rhel', 'suse')
         rpm_package 'pkg' do
           package_name lazy { node.run_state[name] }
           action :install
@@ -249,7 +250,8 @@ action :install do
     dpkg_package lazy { node.run_state['local_installer'] } do
       action :install
     end
-  elsif platform_family?('rhel')
+  #Currently support on suse12
+  elsif platform_family?('rhel', 'suse')
     rpm_package lazy { node.run_state['local_installer'] } do
       action :install
     end


### PR DESCRIPTION
**Chef was failing to install axon agent on SUSE12** 
**Solution**: Chef was picking up the correct installer but was not able to install it because it goes inside the else block where it is taking 'zypper_package' to install/update agent on SUSE but agent installation was failing with 'zypper_package ' resource on suse. so I have added 'suse' along with 'rhel' where it is taking 'rpm_package' and everything is working fine in case of SUSE12. 
Tested Scenarios:
![image](https://user-images.githubusercontent.com/73217885/97673672-290ab300-1ab2-11eb-8239-cf66d35d57d2.png)
@kraigstrong @pfaffle @pbisht-lab 