### PR TITLE
Fix cookbook for lin32 bit installer

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.3'
+version '1.1.4'
 chef_version '>= 13' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -58,7 +58,10 @@ action :install do
 
   # Set platform specific variables
   case node['platform']
-  when 'centos', 'redhat', 'suse', 'oraclelinux', 'oracle', 'amazon'
+  when 'centos', 'redhat', 'suse', 'oraclelinux', 'amazon'
+    ext = '.rpm'
+    eg_service_name = 'tw-eg-service'
+  when 'oracle'
     ext = '.rpm'
     eg_service_name = 'tw-eg-service'
     # for Oracle UEK, need to run few extra commands as pre-requisites


### PR DESCRIPTION
**Problem statement:** Redhat 6.x 32bit and Centos 6.x 32 bit agent installation had started failing recently after merging my PR (https://github.com/Tripwire/chef-tripwire_agent/pull/40). This is bcoz "node["hostnamectl"]["kernel"]' property is not applicable on the these machines and hence causing the failure.
**Solution:** Separated out 'oracle' in a different block. Now, oracle specific code will not effect  Redhat 6.x 32bit and Centos 6.x 32 bit 
Tested Scenarios:
![image](https://user-images.githubusercontent.com/73217885/98220531-6bca0080-1f74-11eb-9aba-ffe60e4da132.png)



@pbisht-lab @kraigstrong @pfaffle 