### PR TITLE
Added support to install dkms package for debian 10 or greater

### DIFF
--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -88,6 +88,15 @@ action :install do
   when 'debian', 'ubuntu'
     ext = '.deb'
     eg_service_name = 'tw-eg-service'
+    if node["platform"].include?('debian')
+      platform_version = node['platform_version'].split('.')[0]
+      if platform_version.to_i >= 10
+        pre_requisite_cmd = "sudo apt-get install linux-headers-$(uname -r)  -y"
+        execute 'Install dkms prerequisites for debian' do
+          command pre_requisite_cmd
+        end
+      end
+    end
   when 'windows'
     ext = '.msi'
     eg_service_name = 'TripwireEventGeneratorService'


### PR DESCRIPTION
For Axon agent now we support DKMS package to install agent.
**Solution:** Added prerequisite command to install dkms (kernal headers) and to select dkms driver, need o set "use_dkms_driver" attribute value to "true".
**Testing:**
![image](https://user-images.githubusercontent.com/73217885/109471508-dd373d00-7a96-11eb-90c0-7c9b2f7a9e08.png)

@kraigstrong  @pbisht-lab 
