### PR TITLE
Add support to install dkms in debian

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'TW-OCTO@tripwire.com'
 license 'Apache-2.0'
 description 'Installs/Configures tripwire_agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.4'
+version '1.1.5'
 chef_version '>= 13' if respond_to?(:chef_version)
 
 source_url 'https://github.com/Tripwire/chef-tripwire_agent'

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -88,13 +88,11 @@ action :install do
   when 'debian', 'ubuntu'
     ext = '.deb'
     eg_service_name = 'tw-eg-service'
-    if node["platform"].include?('debian')
-      platform_version = node['platform_version'].split('.')[0]
-      if platform_version.to_i >= 10
-        pre_requisite_cmd = "sudo apt-get install linux-headers-$(uname -r)  -y"
-        execute 'Install dkms prerequisites for debian' do
-          command pre_requisite_cmd
-        end
+    platform_version = node['platform_version'].split('.')[0]
+    if platform_version.to_i >= 10
+      pre_requisite_cmd = "sudo apt-get install linux-headers-$(uname -r)  -y"
+      execute 'Install dkms prerequisites for debian' do
+        command pre_requisite_cmd
       end
     end
   when 'windows'

--- a/resources/axon.rb
+++ b/resources/axon.rb
@@ -88,6 +88,15 @@ action :install do
   when 'debian', 'ubuntu'
     ext = '.deb'
     eg_service_name = 'tw-eg-service'
+    if node["platform"].include?('debian')
+      platform_version = node['platform_version'].split('.')[0]
+      if platform_version.to_i >= 10
+        pre_requisite_cmd = "sudo apt-get install linux-headers-$(uname -r)  -y"
+        execute 'Install dkms prerequisites for debian' do
+          command pre_requisite_cmd
+        end
+      end
+    end
   when 'windows'
     ext = '.msi'
     eg_service_name = 'TripwireEventGeneratorService'


### PR DESCRIPTION
For Debain and Ubuntu axon agent now we support DKMS package to install agent.
Solution: Added prerequisite command to install dkms (kernal headers) and to select dkms driver, need o set "use_dkms_driver" attribute value to "true".
Testing:
![image](https://user-images.githubusercontent.com/73217885/109642258-bd784580-7b78-11eb-971d-a130aab466b0.png)


@kraigstrong @pbisht-lab  @pfaffle 
