### PR TITLE
Added support to publish cookbook to the public Chef Supermarket

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+  parameters {
+    string(name: 'DOCKER_IMAGE', defaultValue: 'docker-qa-local.docker.scm.tripwire.com/axon/jenkins2/axon-ruby-cookbooks:latest', description: 'Docker image to use.')
+  }
+  agent {
+    docker {
+      label 'docker'
+      image params.DOCKER_IMAGE
+    }
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+  }
+  stages {
+    stage('Publish to Chef Supermarket'){
+      steps {
+        // read USER_NAME from Jenkins
+        withCredentials([file(credentialsId: 'supermarket_key', variable: 'KEY_FILE')]) {
+          sh("chef exec stove --username $USER_NAME --key $KEY_FILE --endpoint https://supermarket.chef.io/api/v1 --no-git --no-ssl-verify")
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,8 @@ pipeline {
   stages {
     stage('Publish to Chef Supermarket'){
       steps {
-        // read USER_NAME from Jenkins
-        withCredentials([file(credentialsId: 'supermarket_key', variable: 'KEY_FILE')]) {
-          sh("chef exec stove --username $USER_NAME --key $KEY_FILE --endpoint https://supermarket.chef.io/api/v1 --no-git --no-ssl-verify")
+        withCredentials([file(credentialsId: 'cap_supermaket', variable: 'KEY_FILE')]) {
+          sh("chef exec stove --username scm --key $KEY_FILE --endpoint https://supermarket.lab.tripwire.com/api/v1 --no-git --no-ssl-verify")
         }
       }
     }


### PR DESCRIPTION
**Testing**

For '[dummy2](https://github.com/pbisht-lab/pbisht-dummy2)' cookbook, successfully published changes to the public Supermarket : PASS
https://jenkins.tripwirelab.com/view/Chef/job/pbisht_dummy2/4/console



**Misc Notes**

- Until the required user is added to the '[tripwire](https://supermarket.chef.io/cookbooks/tripwire_agent)' Chef organisation (in which this cookbook resides), we can't publish any changes to this cookbook in Supermarket and getting '[Unauthorized Request](https://jenkins.tripwirelab.com/view/Chef/job/tripwire_agent/1/console)' as expected
-- I am going to check with the SCM team if that is feasible because AFAIK, the maintainers of this Chef organisation are no more with TW and this resides in public Supermarket
-- **In worst case**, if they say that its not possible for them, then we may have to push a copy of this cookbook to in-house Tripwire Supermarket

- Due to the above mentioned reasons, for now, I have tested this change with a dummy cookbook in public Supermarket with my personal creds

@pfaffle @sachinpatil2488 @bhagyashribangar @asaindane